### PR TITLE
Harden admin tools and logging

### DIFF
--- a/includes/Functions.php
+++ b/includes/Functions.php
@@ -185,12 +185,18 @@ function wca_log_event( $event, array $data = array(), $level = 'info' ) {
 	if ( isset( $data['order_id'] ) ) {
 		$data['order_id'] = (int) $data['order_id'];
 	}
-	$payload = array_merge( array( 'event' => (string) $event ), wca_common_ctx(), $data );
-	$json    = wp_json_encode( $payload, JSON_UNESCAPED_SLASHES );
-	if ( strlen( $json ) > 8000 ) {
-		$json = substr( $json, 0, 8000 ) . '...';
-	}
-	wc_get_logger()->log( $level, $json, array( 'source' => 'wc-antifraud-pro-lite' ) );
+        $payload = array_merge( array( 'event' => (string) $event ), wca_common_ctx(), $data );
+        $json    = wp_json_encode( $payload, JSON_UNESCAPED_SLASHES );
+        if ( ! is_string( $json ) ) {
+                $json = wp_json_encode( array( 'event' => (string) $event, 'error' => 'json_encode_failed' ) );
+                if ( ! is_string( $json ) ) {
+                        return;
+                }
+        }
+        if ( strlen( $json ) > 8000 ) {
+                $json = substr( $json, 0, 8000 ) . '...';
+        }
+        wc_get_logger()->log( $level, $json, array( 'source' => 'wc-antifraud-pro-lite' ) );
 }
 
 /* ----------- Lists & UA ----------- */


### PR DESCRIPTION
## Summary
- Derive cookie domain from `home_url()` and apply `SameSite=Lax`
- Validate referrer host strictly during checkout
- Replace CDN SelectWoo stylesheet with WooCommerce's local asset
- Guard unban tool against invalid keys and add notice for bad attempts
- Tighten settings import with file validation and admin notice
- Ensure logging gracefully handles JSON encoding failures

## Testing
- `php -l includes/Services/FraudEngine.php`
- `php -l includes/Admin/SettingsPage.php`
- `php -l includes/Functions.php`
- `vendor/bin/phpcs --standard=WordPress includes/Services/FraudEngine.php includes/Admin/SettingsPage.php includes/Functions.php` *(fails: existing coding-standard warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f1e1c2c648333b20c2837293c612e