### PR TITLE
Add admin routing with new navigation layout

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -11,6 +11,25 @@
 	gap: 16px;
 	margin-top: 10px;
 }
+
+/* Top navigation */
+.wca-top-nav {
+        margin-top: 12px;
+        display: flex;
+        gap: 8px;
+}
+.wca-top-nav a {
+        padding: 8px 12px;
+        border: 1px solid #c3c4c7;
+        background: #e2e2e2;
+        color: #1d2327;
+        text-decoration: none;
+        border-bottom: none;
+}
+.wca-top-nav a.current {
+        background: #fff;
+        font-weight: 600;
+}
 .wca-actions {
 	display: flex;
 	align-items: center;
@@ -37,7 +56,7 @@
 
 /* Tabs */
 .wca-tabs {
-	margin-top: 12px;
+        margin-top: 12px;
 }
 .wca-tabs .nav-tab {
 	border-radius: 1px 1px 0 0;
@@ -63,7 +82,53 @@
 
 /* Grid of cards */
 .wca-form {
-	margin-top: 12px;
+        margin-top: 12px;
+}
+
+/* Settings layout */
+.wca-settings-grid {
+        display: flex;
+        gap: 20px;
+        margin-top: 20px;
+}
+.wca-vert-nav {
+        width: 200px;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+}
+.wca-vert-nav li {
+        margin-bottom: 4px;
+}
+.wca-vert-nav a {
+        display: block;
+        padding: 8px 10px;
+        border: 1px solid #d0d5da;
+        border-radius: 4px;
+        background: #f0f0f0;
+        text-decoration: none;
+        color: #1d2327;
+}
+.wca-vert-nav li.active a,
+.wca-vert-nav a:hover {
+        background: #fff;
+        font-weight: 600;
+}
+.wca-settings-form {
+        flex: 1;
+}
+@media (max-width: 782px) {
+        .wca-settings-grid {
+                flex-direction: column;
+        }
+        .wca-vert-nav {
+                width: 100%;
+                display: flex;
+                overflow-x: auto;
+        }
+        .wca-vert-nav li {
+                margin-right: 4px;
+        }
 }
 .wca-grid {
 	display: grid;

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -263,11 +263,13 @@
    * Boot
    * --------------------------- */
   $(function () {
-    wcaInitSearch();
-    wcaInitHelpToggles();
-    wcaInitProductSelect();
-    wcaBindPreviewTriggers();
-    // Initial paint
-    wcaUpdateCartPreview();
+    if ($('.wca-settings').length) {
+      wcaInitSearch();
+      wcaInitHelpToggles();
+      wcaInitProductSelect();
+      wcaBindPreviewTriggers();
+      // Initial paint
+      wcaUpdateCartPreview();
+    }
   });
 })(jQuery);

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -15,9 +15,9 @@ function wca_admin_menu() {
 		__( 'Anti-Fraud', 'wc-anti-fraud-pro-lite' ),
 		__( 'Anti-Fraud', 'wc-anti-fraud-pro-lite' ),
 		'manage_woocommerce',
-		WCA_MENU_SLUG,
-		'wca_settings_page_tabs'
-	);
+               WCA_MENU_SLUG,
+               'wca_admin_page'
+        );
 }
 
 /* Enqueue admin assets only on our page */
@@ -135,97 +135,118 @@ function wca_sanitize_opts_ext( $input ) {
 	return $out;
 }
 
-/* Settings page (tabs) */
-function wca_settings_page_tabs() {
-	$schema = wca_fields_schema();
-	$opts   = wca_opt();
-	$tab    = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : 'general';
-	if ( ! isset( $schema[ $tab ] ) ) {
-		$tab = 'general';
-	}
+/* Main admin page router */
+function wca_admin_page() {
+        $section = isset( $_GET['section'] ) ? sanitize_key( $_GET['section'] ) : 'dashboard';
+        $allowed = array( 'dashboard', 'logs', 'settings' );
+        if ( ! in_array( $section, $allowed, true ) ) {
+                $section = 'dashboard';
+        }
 
-	$base = menu_page_url( WCA_MENU_SLUG, false );
-	?>
-	<div class="wrap wca-wrap">
-		<h1><?php esc_html_e( 'WooCommerce Anti-Fraud (Lite)', 'wc-anti-fraud-pro-lite' ); ?></h1>
-		<div class="wca-header">
-			<div class="wca-actions">
-				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="wca-inline">
-					<?php wp_nonce_field( 'wca_export_nonce', 'wca_export_nonce' ); ?>
-					<input type="hidden" name="action" value="wca_export">
-					<button class="button"><?php esc_html_e( 'Export', 'wc-anti-fraud-pro-lite' ); ?></button>
-				</form>
-				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="wca-inline" enctype="multipart/form-data">
-					<?php wp_nonce_field( 'wca_import_nonce', 'wca_import_nonce' ); ?>
-					<input type="hidden" name="action" value="wca_import">
-					<label class="wca-file">
-						<input type="file" name="wca_file" accept="application/json" />
-						<span><?php esc_html_e( 'Choose JSON', 'wc-anti-fraud-pro-lite' ); ?></span>
-					</label>
-					<button class="button button-primary"><?php esc_html_e( 'Import', 'wc-anti-fraud-pro-lite' ); ?></button>
-				</form>
-				<input type="search" id="wca-search" class="wca-search" placeholder="<?php esc_attr_e( 'Search settings…', 'wc-anti-fraud-pro-lite' ); ?>">
-			</div>
-		</div>
+        $base = menu_page_url( WCA_MENU_SLUG, false );
+        $schema = wca_fields_schema();
+        $opts   = wca_opt();
+        $tab    = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : 'general';
+        if ( ! isset( $schema[ $tab ] ) ) {
+                $tab = 'general';
+        }
+        ?>
+        <div class="wrap wca-wrap">
+                <h1><?php esc_html_e( 'WooCommerce Anti-Fraud (Lite)', 'wc-anti-fraud-pro-lite' ); ?></h1>
 
-		<h2 class="nav-tab-wrapper wca-tabs">
-			<?php foreach ( $schema as $key => $group ) : ?>
-				<a class="nav-tab <?php echo $key === $tab ? 'nav-tab-active' : ''; ?>"
-					href="<?php echo esc_url( add_query_arg( 'tab', $key, $base ) ); ?>">
-					<?php echo esc_html( $group['title'] ); ?>
-				</a>
-			<?php endforeach; ?>
-		</h2>
+                <nav class="wca-top-nav">
+                        <a href="<?php echo esc_url( add_query_arg( 'section', 'dashboard', $base ) ); ?>" class="<?php echo $section === 'dashboard' ? 'current' : ''; ?>"><?php esc_html_e( 'Dashboard', 'wc-anti-fraud-pro-lite' ); ?></a>
+                        <a href="<?php echo esc_url( add_query_arg( 'section', 'logs', $base ) ); ?>" class="<?php echo $section === 'logs' ? 'current' : ''; ?>"><?php esc_html_e( 'Logs', 'wc-anti-fraud-pro-lite' ); ?></a>
+                        <a href="<?php echo esc_url( add_query_arg( 'section', 'settings', $base ) ); ?>" class="<?php echo $section === 'settings' ? 'current' : ''; ?>"><?php esc_html_e( 'Settings', 'wc-anti-fraud-pro-lite' ); ?></a>
+                </nav>
 
-		<form method="post" action="options.php" class="wca-form">
-			<?php settings_fields( 'wca_group_ext' ); ?>
+                <?php if ( $section === 'settings' ) : ?>
+                        <div class="wca-header">
+                                <div class="wca-actions">
+                                        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="wca-inline">
+                                                <?php wp_nonce_field( 'wca_export_nonce', 'wca_export_nonce' ); ?>
+                                                <input type="hidden" name="action" value="wca_export">
+                                                <button class="button"><?php esc_html_e( 'Export', 'wc-anti-fraud-pro-lite' ); ?></button>
+                                        </form>
+                                        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="wca-inline" enctype="multipart/form-data">
+                                                <?php wp_nonce_field( 'wca_import_nonce', 'wca_import_nonce' ); ?>
+                                                <input type="hidden" name="action" value="wca_import">
+                                                <label class="wca-file">
+                                                        <input type="file" name="wca_file" accept="application/json" />
+                                                        <span><?php esc_html_e( 'Choose JSON', 'wc-anti-fraud-pro-lite' ); ?></span>
+                                                </label>
+                                                <button class="button button-primary"><?php esc_html_e( 'Import', 'wc-anti-fraud-pro-lite' ); ?></button>
+                                        </form>
+                                        <input type="search" id="wca-search" class="wca-search" placeholder="<?php esc_attr_e( 'Search settings…', 'wc-anti-fraud-pro-lite' ); ?>">
+                                </div>
+                        </div>
 
-			<?php if ( ! empty( $schema[ $tab ]['fields'] ) ) : ?>
-				<div class="wca-grid">
-					<?php
-					foreach ( $schema[ $tab ]['fields'] as $f ) :
-						$id    = $f[0];
-						$type  = $f[1];
-						$label = $f[2];
-						$def   = $f[3];
-						$help  = $f[4] ?? '';
-						$val   = isset( $opts[ $id ] ) ? $opts[ $id ] : $def;
-						?>
-						<section class="wca-card wca-field" data-search="<?php echo esc_attr( strtolower( $label . ' ' . ( is_string( $help ) ? $help : implode( ' ', $help ) ) ) ); ?>">
-							<header class="wca-card-h">
-								<h3><?php echo esc_html( $label ); ?></h3>
-								<?php if ( ! empty( $help ) ) : ?>
-									<button type="button" class="wca-help" aria-label="<?php esc_attr_e( 'Help', 'wc-anti-fraud-pro-lite' ); ?>">?</button>
-								<?php endif; ?>
-							</header>
-							<div class="wca-card-b">
-								<?php wca_render_input( $id, $type, $val, $help ); ?>
-							</div>
-						</section>
-					<?php endforeach; ?>
-				</div>
-			<?php else : ?>
-				<p><?php esc_html_e( 'No configurable fields on this tab.', 'wc-anti-fraud-pro-lite' ); ?></p>
-			<?php endif; ?>
+                        <div class="wca-settings-grid wca-settings">
+                                <ul class="wca-vert-nav">
+                                        <?php foreach ( $schema as $key => $group ) : ?>
+                                                <li class="<?php echo $key === $tab ? 'active' : ''; ?>">
+                                                        <a href="<?php echo esc_url( add_query_arg( array( 'section' => 'settings', 'tab' => $key ), $base ) ); ?>">
+                                                                <?php echo esc_html( $group['title'] ); ?>
+                                                        </a>
+                                                </li>
+                                        <?php endforeach; ?>
+                                </ul>
 
-			<div class="wca-savebar">
-				<?php submit_button( null, 'primary', 'submit', false ); ?>
-			</div>
-		</form>
+                                <div class="wca-settings-form">
+                                        <form method="post" action="options.php" class="wca-form">
+                                                <?php settings_fields( 'wca_group_ext' ); ?>
 
-		<?php if ( $tab === 'maintenance' ) : ?>
-			<div class="wca-tools">
-				<h3><?php esc_html_e( 'Maintenance Tools', 'wc-anti-fraud-pro-lite' ); ?></h3>
-				<p class="description"><?php esc_html_e( 'Clear rate-limit counters and temp bans. Logs: Woo → Status → Logs → wc-antifraud-pro-lite', 'wc-anti-fraud-pro-lite' ); ?></p>
-				<form method="post">
-					<?php wp_nonce_field( 'wca_tools_nonce', 'wca_tools_nonce' ); ?>
-					<input type="hidden" name="wca_tool" value="clear-transients">
-					<button class="button"><?php esc_html_e( 'Clear Counters / Bans', 'wc-anti-fraud-pro-lite' ); ?></button>
-				</form>
-			</div>
-		<?php endif; ?>
-	</div>
-	<?php
+                                                <?php if ( ! empty( $schema[ $tab ]['fields'] ) ) : ?>
+                                                        <div class="wca-grid">
+                                                                <?php
+                                                                foreach ( $schema[ $tab ]['fields'] as $f ) :
+                                                                        $id    = $f[0];
+                                                                        $type  = $f[1];
+                                                                        $label = $f[2];
+                                                                        $def   = $f[3];
+                                                                        $help  = $f[4] ?? '';
+                                                                        $val   = isset( $opts[ $id ] ) ? $opts[ $id ] : $def;
+                                                                        ?>
+                                                                        <section class="wca-card wca-field" data-search="<?php echo esc_attr( strtolower( $label . ' ' . ( is_string( $help ) ? $help : implode( ' ', $help ) ) ) ); ?>">
+                                                                                <header class="wca-card-h">
+                                                                                        <h3><?php echo esc_html( $label ); ?></h3>
+                                                                                        <?php if ( ! empty( $help ) ) : ?>
+                                                                                                <button type="button" class="wca-help" aria-label="<?php esc_attr_e( 'Help', 'wc-anti-fraud-pro-lite' ); ?>">?</button>
+                                                                                        <?php endif; ?>
+                                                                                </header>
+                                                                                <div class="wca-card-b">
+                                                                                        <?php wca_render_input( $id, $type, $val, $help ); ?>
+                                                                                </div>
+                                                                        </section>
+                                                                <?php endforeach; ?>
+                                                        </div>
+                                                <?php else : ?>
+                                                        <p><?php esc_html_e( 'No configurable fields on this tab.', 'wc-anti-fraud-pro-lite' ); ?></p>
+                                                <?php endif; ?>
+
+                                                <div class="wca-savebar">
+                                                        <?php submit_button( null, 'primary', 'submit', false ); ?>
+                                                </div>
+                                        </form>
+                                </div>
+                        </div>
+                <?php elseif ( $section === 'logs' ) : ?>
+                        <?php wca_render_logs(); ?>
+                <?php else : ?>
+                        <?php wca_render_dashboard(); ?>
+                <?php endif; ?>
+        </div>
+        <?php
+}
+
+/* Dashboard placeholder */
+function wca_render_dashboard() {
+        echo '<p>' . esc_html__( 'Dashboard coming soon.', 'wc-anti-fraud-pro-lite' ) . '</p>';
+}
+
+/* Logs placeholder */
+function wca_render_logs() {
+        echo '<p>' . esc_html__( 'Logs viewer coming soon.', 'wc-anti-fraud-pro-lite' ) . '</p>';
 }
 
 /* Render one input (compact, modern) */

--- a/wc-anti-fraud-pro-lite.php
+++ b/wc-anti-fraud-pro-lite.php
@@ -39,6 +39,7 @@ add_action( 'init', 'wca_load_textdomain' );
 require_once WCA_PLUGIN_DIR . 'includes/Presets.php';
 require_once WCA_PLUGIN_DIR . 'includes/Functions.php';
 require_once WCA_PLUGIN_DIR . 'includes/Admin/Schema.php';
+// Admin pages (dashboard, logs, settings)
 require_once WCA_PLUGIN_DIR . 'includes/Admin/SettingsPage.php';
 require_once WCA_PLUGIN_DIR . 'includes/Services/FraudEngine.php';
 require_once WCA_PLUGIN_DIR . 'includes/Services/Telemetry.php';


### PR DESCRIPTION
## Summary
- Route Anti-Fraud admin page by `section` query parameter
- Introduce top navigation and vertical settings sidebar
- Gate settings scripts to run only on settings section

## Testing
- `php -l includes/Admin/SettingsPage.php`
- `php -l wc-anti-fraud-pro-lite.php`


------
https://chatgpt.com/codex/tasks/task_e_689f265f44e4833386b1299b48cb7388