### PR TITLE
Cache dashboard stats with transient

### DIFF
--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -460,7 +460,10 @@ function wca_on_settings_updated( $old, $new ) {
 			$changed[] = $k;
 		}
 	}
-	if ( $changed ) {
-		wca_log_event( 'settings_updated', array( 'keys' => $changed ), 'info' );
-	}
+       if ( $changed ) {
+               wca_log_event( 'settings_updated', array( 'keys' => $changed ), 'info' );
+       }
+
+       // Invalidate cached dashboard stats when settings change.
+       delete_transient( 'wca_dash_stats' );
 }


### PR DESCRIPTION
## Summary
- Cache dashboard analytics in transient `wca_dash_stats` for 5 minutes and reuse cached values when valid.
- Invalidate cached dashboard stats when plugin settings change.

## Testing
- `composer install`
- `vendor/bin/phpcs includes/Admin/DashboardPage.php includes/Admin/SettingsPage.php` *(fails: numerous coding standard violations)*
- `php -l includes/Admin/DashboardPage.php includes/Admin/SettingsPage.php`

------
https://chatgpt.com/codex/tasks/task_e_689f3980c5bc8333969220cbf9f0ff22