### PR TITLE
Improve sanitization and logging utilities

### DIFF
--- a/includes/Admin/DashboardPage.php
+++ b/includes/Admin/DashboardPage.php
@@ -83,6 +83,14 @@ function wca_render_dashboard() {
         }
 
         $bans = function_exists( 'wca_list_bans' ) ? wca_list_bans() : array();
+
+       $product_titles = array();
+       if ( $products && function_exists( 'wc_get_products' ) ) {
+               $objs = wc_get_products( array( 'include' => array_keys( $products ) ) );
+               foreach ( $objs as $obj ) {
+                       $product_titles[ $obj->get_id() ] = $obj->get_name();
+               }
+       }
         ?>
         <div class="wca-grid">
                 <section class="wca-card">
@@ -127,9 +135,9 @@ function wca_render_dashboard() {
                         <div class="wca-card-b">
                                 <?php if ( $products ) : ?>
                                         <ul>
-                                                <?php foreach ( $products as $pid => $cnt ) : ?>
-                                                        <li><?php echo esc_html( get_the_title( $pid ) . ' (#' . $pid . ') – ' . $cnt ); ?></li>
-                                                <?php endforeach; ?>
+                                               <?php foreach ( $products as $pid => $cnt ) : ?>
+                                                       <li><?php echo esc_html( ( $product_titles[ $pid ] ?? '' ) . ' (#' . $pid . ') – ' . $cnt ); ?></li>
+                                               <?php endforeach; ?>
                                         </ul>
                                 <?php else : ?>
                                         <p><?php esc_html_e( 'No data', 'wc-anti-fraud-pro-lite' ); ?></p>

--- a/includes/Admin/LogsPage.php
+++ b/includes/Admin/LogsPage.php
@@ -11,6 +11,10 @@ if (! class_exists('WP_List_Table') ) {
  * Read and parse plugin log file lines.
  *
  * @return array[] Parsed entries with keys: time, level, event, context, raw, country, ip, items.
+ *
+ * @since 1.0.0
+ *
+ * @filter wca_log_tail_limit int Maximum number of log lines to read from the end of the file. Default 5000.
  */
 function wca_get_log_entries()
 {
@@ -21,7 +25,7 @@ function wca_get_log_entries()
     if (! file_exists($path) ) {
             return array();
     }
-       $limit = 5000; // Only read the last 5,000 lines to limit memory usage; adjust as needed.
+       $limit = apply_filters( 'wca_log_tail_limit', 5000 ); // Only read the last 5,000 lines to limit memory usage; adjust as needed.
        $file  = new SplFileObject($path, 'r');
        $file->seek(PHP_INT_MAX);
        $last_line = $file->key();

--- a/includes/Functions.php
+++ b/includes/Functions.php
@@ -141,9 +141,9 @@ function wca_redact_ip( $ip ) {
 	return $ip;
 }
 function wca_common_ctx() {
-	$uid   = get_current_user_id();
-	$ua    = $_SERVER['HTTP_USER_AGENT'] ?? '';
-	$ref   = $_SERVER['HTTP_REFERER'] ?? '';
+        $uid   = get_current_user_id();
+        $ua    = sanitize_text_field( $_SERVER['HTTP_USER_AGENT'] ?? '' );
+        $ref   = esc_url_raw( $_SERVER['HTTP_REFERER'] ?? '' );
 	$ip    = wca_ip();
 	$total = 0.0;
 	$items = array();


### PR DESCRIPTION
## Summary
- preserve escape sequences when sanitizing phone and postal regex options
- sanitize user agent and referer in log context
- preload product titles on dashboard to avoid per-item lookups
- make log tail limit filterable and document the hook
- clear plugin transients using option APIs instead of raw SQL

## Testing
- `php -l includes/Admin/SettingsPage.php`
- `php -l includes/Admin/DashboardPage.php`
- `php -l includes/Admin/LogsPage.php`
- `php -l includes/Functions.php`


------
https://chatgpt.com/codex/tasks/task_e_689f454996508333b3cbb3d3a3e46a91