### PR TITLE
Harden referrer checks and admin pages

### DIFF
--- a/includes/Admin/DashboardPage.php
+++ b/includes/Admin/DashboardPage.php
@@ -84,6 +84,13 @@ function wca_render_dashboard() {
 
         $bans = function_exists( 'wca_list_bans' ) ? wca_list_bans() : array();
 
+       if ( $ips ) {
+               $ips = array_combine(
+                       array_map( 'wca_redact_ip', array_keys( $ips ) ),
+                       array_values( $ips )
+               );
+       }
+
        $product_titles = array();
        if ( $products && function_exists( 'wc_get_products' ) ) {
                $objs = wc_get_products( array( 'include' => array_keys( $products ) ) );

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -153,6 +153,11 @@ function wca_sanitize_opts_ext( $input ) {
 
 /* Main admin page router */
 function wca_admin_page() {
+        if ( ! current_user_can( 'manage_woocommerce' ) ) {
+                echo '<div class="notice notice-error"><p>' . esc_html__( 'You do not have permission to access this page.', 'wc-anti-fraud-pro-lite' ) . '</p></div>';
+                return;
+        }
+
         $section = isset( $_GET['section'] ) ? sanitize_key( $_GET['section'] ) : 'dashboard';
         $allowed = array( 'dashboard', 'logs', 'settings' );
         if ( ! in_array( $section, $allowed, true ) ) {

--- a/includes/Services/FraudEngine.php
+++ b/includes/Services/FraudEngine.php
@@ -81,10 +81,10 @@ function wca_validate_checkout( $data, $errors ) {
 		return;
 	}
 
-	$ip   = wca_ip();
-	$ua   = $_SERVER['HTTP_USER_AGENT'] ?? '';
-	$ref  = $_SERVER['HTTP_REFERER'] ?? '';
-	$host = $_SERVER['SERVER_NAME'] ?? '';
+        $ip   = wca_ip();
+        $ua   = $_SERVER['HTTP_USER_AGENT'] ?? '';
+        $ref  = $_SERVER['HTTP_REFERER'] ?? '';
+        $host = sanitize_text_field( parse_url( home_url(), PHP_URL_HOST ) );
 
 	if ( $ip && in_array( $ip, wca_lines_to_array( $o['ip_whitelist'] ), true ) ) {
 		return;
@@ -168,7 +168,7 @@ function wca_validate_checkout( $data, $errors ) {
 
 	// Referrer / UA
         if ( ! empty( $o['strict_ref'] ) ) {
-                $ref_host               = $ref ? parse_url( $ref, PHP_URL_HOST ) : '';
+                $ref_host               = $ref ? sanitize_text_field( parse_url( $ref, PHP_URL_HOST ) ) : '';
                 $checks['referrer_ok']  = ( $ref_host && $ref_host === $host );
                 if ( ! $checks['referrer_ok'] ) {
                         $block     = true;


### PR DESCRIPTION
## Summary
- Use `home_url()` host and sanitize referrer hosts before strict comparison
- Build dynamic log event filter, sanitize limit, and redact dashboard IPs
- Restrict settings page to `manage_woocommerce` capability

## Testing
- `php -l includes/Services/FraudEngine.php`
- `php -l includes/Admin/LogsPage.php`
- `php -l includes/Admin/DashboardPage.php`
- `php -l includes/Admin/SettingsPage.php`
- `vendor/bin/phpcs --standard=WordPress --extensions=php includes/Services/FraudEngine.php includes/Admin/LogsPage.php includes/Admin/DashboardPage.php includes/Admin/SettingsPage.php` *(fails: tabs vs spaces, existing codebase)*

------
https://chatgpt.com/codex/tasks/task_e_689f4800f3288333ba69e85832613b9b