### PR TITLE
Ensure unchecked checkboxes submit default value

### DIFF
--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -280,6 +280,7 @@ function wca_render_input( $id, $type, $val, $help ) {
 	echo '<div class="wca-input">';
 	switch ( $type ) {
 		case 'checkbox':
+			echo '<input type="hidden" name="wca_opts_ext[' . esc_attr( $id ) . ']" value="0">';
 			echo '<label class="wca-switch"><input type="checkbox" name="wca_opts_ext[' . esc_attr( $id ) . ']" value="1" ' . checked( $val, 1, false ) . '><span class="wca-slider"></span></label>';
 			break;
 


### PR DESCRIPTION
## Summary
- ensure checkboxes submit `0` when left unchecked by adding hidden field

## Testing
- `composer install`
- `php -l includes/Admin/SettingsPage.php`
- `vendor/bin/phpcs includes/Admin/SettingsPage.php --standard=WordPress` *(fails: existing coding standard errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f5064fa908333a0813fd0ac632f53