### PR TITLE
Enhance admin settings layout and semantics

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -95,24 +95,31 @@
         width: 200px;
         list-style: none;
         margin: 0;
-        padding: 0;
+       padding: 0;
 }
 .wca-vert-nav li {
         margin-bottom: 4px;
 }
 .wca-vert-nav a {
-        display: block;
-        padding: 8px 10px;
-        border: 1px solid #d0d5da;
-        border-radius: 4px;
-        background: #f0f0f0;
-        text-decoration: none;
-        color: #1d2327;
+       display: block;
+       padding: 12px 16px;
+       border: 1px solid #d0d5da;
+       border-radius: 4px;
+       background: #f0f0f0;
+       text-decoration: none;
+       color: #1d2327;
+       font-size: 14px;
+       font-weight: 500;
 }
-.wca-vert-nav li.active a,
 .wca-vert-nav a:hover {
-        background: #fff;
-        font-weight: 600;
+       background: #fff;
+}
+.wca-vert-nav li.active a {
+       background: #fff;
+       font-weight: 600;
+       color: #0a4b78;
+       border-left: 4px solid #2271b1;
+       padding-left: 12px;
 }
 .wca-settings-form {
         flex: 1;
@@ -136,11 +143,12 @@
 	gap: 14px;
 }
 .wca-card {
-	grid-column: span 6;
-	background: #fff;
-	border: 1px solid #e4e6eb;
-	border-radius: 10px;
-	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.02);
+        grid-column: span 6;
+        background: #fff;
+        border: 1px solid #e4e6eb;
+       border-radius: 10px;
+       box-shadow: 0 1px 1px rgba(0, 0, 0, 0.02);
+       padding: 0;
 }
 @media (max-width: 1024px) {
 	.wca-card {
@@ -148,16 +156,15 @@
 	}
 }
 .wca-card-h {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	padding: 12px 14px;
-	border-bottom: 1px solid #eef0f3;
-}
-.wca-card-h h3 {
-	margin: 0;
-	font-size: 14px;
-	font-weight: 600;
+       display: flex;
+       align-items: center;
+       justify-content: space-between;
+       padding: 16px 20px;
+       border-bottom: 1px solid #eef0f3;
+       font-size: 16px;
+       font-weight: 600;
+       margin: 0;
+       width: 100%;
 }
 .wca-help {
 	width: 28px;
@@ -171,7 +178,7 @@
 	justify-content: center;
 }
 .wca-card-b {
-	padding: 14px;
+       padding: 20px;
 }
 
 /* Inputs */

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -216,7 +216,7 @@
 
     var run = debounce(function () {
       var q = ($search.val() || '').toLowerCase();
-      $('.wca-field').each(function () {
+      $('fieldset.wca-field').each(function () {
         var $f = $(this);
         var hay = (($f.data('search') || '') + '').toLowerCase();
         $f.toggle(!q || hay.indexOf(q) !== -1);
@@ -264,7 +264,7 @@
    * Toggle field dependencies
    * --------------------------- */
   function wcaToggleDependencies() {
-    $('.wca-field[data-depends]').each(function () {
+    $('fieldset.wca-field[data-depends]').each(function () {
       var $field = $(this);
       var dep = $field.data('depends');
       var $input = $('input[name="wca_opts_ext[' + dep + ']"]');

--- a/includes/Admin/SettingsPage.php
+++ b/includes/Admin/SettingsPage.php
@@ -240,22 +240,22 @@ function wca_admin_page() {
                                                                        $val     = isset( $opts[ $id ] ) ? $opts[ $id ] : $def;
                                                                        $depends = isset( $f['depends'] ) ? $f['depends'] : '';
                                                                        ?>
-                                                                       <section class="wca-card wca-field" data-search="<?php echo esc_attr( strtolower( $label . ' ' . ( is_string( $help ) ? $help : implode( ' ', $help ) ) ) ); ?>"<?php echo $depends ? ' data-depends="' . esc_attr( $depends ) . '"' : ''; ?>>
-                                                                                <header class="wca-card-h">
-                                                                                        <h3><?php echo esc_html( $label ); ?></h3>
-                                                                                        <?php if ( ! empty( $help ) ) : ?>
-                                                                                                <button type="button" class="wca-help" aria-label="<?php esc_attr_e( 'Help', 'wc-anti-fraud-pro-lite' ); ?>">?</button>
-                                                                                        <?php endif; ?>
-                                                                                </header>
-                                                                                <div class="wca-card-b">
-                                                                                        <?php wca_render_input( $id, $type, $val, $help ); ?>
-                                                                                </div>
-                                                                        </section>
-                                                                <?php endforeach; ?>
-                                                        </div>
-                                                <?php else : ?>
-                                                        <p><?php esc_html_e( 'No configurable fields on this tab.', 'wc-anti-fraud-pro-lite' ); ?></p>
-                                                <?php endif; ?>
+                                                                       <fieldset class="wca-card wca-field" data-search="<?php echo esc_attr( strtolower( $label . ' ' . ( is_string( $help ) ? $help : implode( ' ', $help ) ) ) ); ?>"<?php echo $depends ? ' data-depends="' . esc_attr( $depends ) . '"' : ''; ?>>
+                                                                               <legend class="wca-card-h">
+                                                                                       <?php echo esc_html( $label ); ?>
+                                                                                       <?php if ( ! empty( $help ) ) : ?>
+                                                                                               <button type="button" class="wca-help" aria-label="<?php esc_attr_e( 'Help', 'wc-anti-fraud-pro-lite' ); ?>">?</button>
+                                                                                       <?php endif; ?>
+                                                                               </legend>
+                                                                               <div class="wca-card-b">
+                                                                                       <?php wca_render_input( $id, $type, $val, $help ); ?>
+                                                                               </div>
+                                                                       </fieldset>
+                                                               <?php endforeach; ?>
+                                                       </div>
+                                               <?php else : ?>
+                                                       <p><?php esc_html_e( 'No configurable fields on this tab.', 'wc-anti-fraud-pro-lite' ); ?></p>
+                                               <?php endif; ?>
 
                                                 <div class="wca-savebar">
                                                         <?php submit_button( null, 'primary', 'submit', false ); ?>


### PR DESCRIPTION
## Summary
- improve vertical nav and card spacing and highlight active tabs with left border
- wrap settings sections in fieldsets with legends for better semantics
- update JS selectors to support new fieldset markup

## Testing
- `php -l includes/Admin/SettingsPage.php`
- `node --check assets/admin.js && echo 'JS syntax OK'`
- `composer validate --no-check-all --ansi`


------
https://chatgpt.com/codex/tasks/task_e_689f52e694148333bbea31e0c9145e9d